### PR TITLE
fix AttributeError on double-star dicts

### DIFF
--- a/logging_format/visitor.py
+++ b/logging_format/visitor.py
@@ -146,7 +146,8 @@ class LoggingVisitor(NodeVisitor):
 
         if self.should_check_extra_field_clash(node):
             for key in node.keys:
-                if key.s in RESERVED_ATTRS:
+                # key can be None if the dict uses double star syntax
+                if key is not None and key.s in RESERVED_ATTRS:
                     self.violations.append((self.current_logging_call, EXTRA_ATTR_CLASH_VIOLATION.format(key.s)))
 
         if self.should_check_extra_exception(node):


### PR DESCRIPTION
Dicts that use `{'foo': "bar", **baz}` syntax have `key` set to None for `baz`, we need to check it before accessing an attribute, otherwise we get an error like that:

```
  File "/Users/foobar/python3.10/site-packages/logging_format/visitor.py", line 149, in visit_Dict
    if key.s in RESERVED_ATTRS:
AttributeError: 'NoneType' object has no attribute 's'
```